### PR TITLE
Enhance alt-text UI and fix download rerun

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from utils.pdf_utils import extract_images_from_pdf
 from utils.preprocess import preprocess_image
 from utils.alt_text_generator import generate_alt_text
-from utils.helpers import label_output, ensure_dir_exists
+from utils.helpers import label_output, ensure_dir_exists, image_to_base64
 
 st.set_page_config(page_title=" PDF Alt-Text Generator", layout="wide")
 
@@ -46,6 +46,22 @@ st.markdown(
 
     .stSidebar {
         background-color: #121212 !important;
+    }
+    .result-card {
+        background-color: #1c1c1c;
+        border: 1px solid #00bfff;
+        border-radius: 10px;
+        padding: 10px;
+        margin-bottom: 16px;
+    }
+    .result-card img {
+        width: 100%;
+        border-radius: 6px;
+    }
+    .alt-text {
+        margin-top: 8px;
+        color: #00ffcc;
+        font-style: italic;
     }
     </style>
     """,
@@ -94,35 +110,50 @@ if uploaded_file:
         pdf_bytes = uploaded_file.read()
         images_by_page = extract_images_from_pdf(io.BytesIO(pdf_bytes))
 
+        total_images = sum(len(imgs) for imgs in images_by_page.values())
+        progress = st.progress(0)
+
         output_lines = []
         flagged = []
         logos = 0
-        total = 0
+        processed = 0
 
         for page_num, images in images_by_page.items():
-            for idx, image in enumerate(images):
-                total += 1
-                cleaned_img, is_logo, was_flagged, reason = preprocess_image(image)
+            with st.expander(f"Page {page_num}"):
+                for idx, image in enumerate(images):
+                    processed += 1
+                    cleaned_img, is_logo, was_flagged, reason = preprocess_image(image)
 
-                alt_text = generate_alt_text(
-                    cleaned_img,
-                    selected_model,
-                    openai_key,
-                    groq_key,
-                    is_logo=is_logo,
-                    alt_line_count=alt_lines,
-                    language=language,
-                )
+                    alt_text = generate_alt_text(
+                        cleaned_img,
+                        selected_model,
+                        openai_key,
+                        groq_key,
+                        is_logo=is_logo,
+                        alt_line_count=alt_lines,
+                        language=language,
+                    )
 
-                label = label_output(page_num, idx + 1, alt_text)
-                if was_flagged:
-                    label += f"\n(Note: ⚠️ {reason})"
-                    flagged.append(f"Page {page_num} - Image {idx + 1}: {reason}")
-                if is_logo:
-                    logos += 1
+                    label = label_output(page_num, idx + 1, alt_text)
+                    if was_flagged:
+                        label += f"\n(Note: ⚠️ {reason})"
+                        flagged.append(f"Page {page_num} - Image {idx + 1}: {reason}")
+                    if is_logo:
+                        logos += 1
 
-                output_lines.append(label)
-                st.success(f"🖼️ {label}", icon="✅")
+                    output_lines.append(label)
+
+                    card_html = f"""
+                    <div class='result-card'>
+                        <img src='data:image/png;base64,{image_to_base64(cleaned_img)}' />
+                        <p class='alt-text'>{alt_text}</p>
+                    </div>
+                    """
+                    st.markdown(card_html, unsafe_allow_html=True)
+
+                    progress.progress(processed / total_images)
+
+        progress.empty()
 
         if flagged:
             st.markdown("### ⚠️ Flagged Images")
@@ -139,16 +170,18 @@ if uploaded_file:
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(alt_text_final)
 
-    # Download + reset upload
+    metrics = st.columns(3)
+    metrics[0].metric("Images", total_images)
+    metrics[1].metric("Logos", logos)
+    metrics[2].metric("Flagged", len(flagged))
+
     if st.download_button(
         label="📥 Download Alt-Text File",
         data=alt_text_final,
         file_name=output_filename,
-        mime="text/plain"
+        mime="text/plain",
     ):
-        st.success("✅ Downloaded! Upload reset.")
-        st.session_state.clear()
-        st.rerun()
+        st.success("✅ Downloaded!")
 
 else:
     st.warning(" Please upload a PDF to begin.")


### PR DESCRIPTION
## Summary
- modernize Streamlit styling with result cards
- display images with generated alt-text and show progress
- add metrics for processed, logo and flagged images
- stop rerunning after file download

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cef998b48329a4a4ed9ec314372b